### PR TITLE
Hide comment icon on mouse up without a selection

### DIFF
--- a/src/components/MonacoEditor/index.tsx
+++ b/src/components/MonacoEditor/index.tsx
@@ -210,6 +210,8 @@ const MonacoEditor: React.FC<IProps> = ({
       setSelectionRange(selection);
       setMousePosition({ x: e.clientX, y: e.clientY });
       setSelectionValue(value);
+    } else {
+      handleHideCommentIcon();
     }
   }
 


### PR DESCRIPTION
This PR hides the comment icon during a mouse up even if there is no selection. 