### PR TITLE
Add openInNew icon to inlineCodeComment

### DIFF
--- a/src/components/Console/styles.ts
+++ b/src/components/Console/styles.ts
@@ -61,6 +61,7 @@ export const useStyles = makeStyles(theme => ({
     color: color.white,
     width: '100%',
     height: '100%',
+    fontSize: fontsize.base,
   },
   saveReadmeButton: {
     margin: theme.spacing(1),

--- a/src/components/InlineCodeComment/index.tsx
+++ b/src/components/InlineCodeComment/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Paper, Button, Tabs, Tab, withStyles } from '@material-ui/core';
+import { OpenInNew as OpenInNewIcon } from '@material-ui/icons';
 
 import { useStyles } from './styles';
 import { IBannerStyle, IDuration } from '../../atoms/NotificationBanner';
@@ -148,6 +149,7 @@ const InlineCodeComment: React.FC<IProps> = ({
             target="_blank"
             className={classes.markdownLink}>
             Markdown is supported
+            <OpenInNewIcon style={{ fontSize: 16, marginBottom: 3 }} />
           </Typography>
           <div className={commonCss.flexRow}>
             <Button className={commonCss.cancelButton} onClick={handleCancelComment}>

--- a/src/components/InlineCodeComment/index.tsx
+++ b/src/components/InlineCodeComment/index.tsx
@@ -149,7 +149,7 @@ const InlineCodeComment: React.FC<IProps> = ({
             target="_blank"
             className={classes.markdownLink}>
             Markdown is supported
-            <OpenInNewIcon style={{ fontSize: 16, marginBottom: 3 }} />
+            <OpenInNewIcon className={classes.openInNewIcon} />
           </Typography>
           <div className={commonCss.flexRow}>
             <Button className={commonCss.cancelButton} onClick={handleCancelComment}>

--- a/src/components/InlineCodeComment/styles.ts
+++ b/src/components/InlineCodeComment/styles.ts
@@ -41,6 +41,8 @@ export const useStyles = makeStyles(theme => ({
     fontSize: fontsize.small,
     fontFamily: `${fonts.semiBold} !important`,
     textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
   },
   commentBoxContainer: {
     position: 'absolute',

--- a/src/components/InlineCodeComment/styles.ts
+++ b/src/components/InlineCodeComment/styles.ts
@@ -62,4 +62,9 @@ export const useStyles = makeStyles(theme => ({
   commentDialogContent: {
     fontSize: 15,
   },
+  openInNewIcon: {
+    fontSize: 16,
+    marginBottom: 3,
+    marginLeft: 3,
+  },
 }));

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -91,7 +91,10 @@ const Home: React.FC<IProps> = ({ onSetNotificationSettings, Api }) => {
   function renderSwitchView() {
     const IconComponent = currentSection === 'console' ? InsertCommentIcon : CodeIcon;
     return (
-      <Tooltip title="Switch View" placement="left" enterDelay={100}>
+      <Tooltip
+        title={currentSection === 'console' ? 'chat' : 'terminal'}
+        placement="left"
+        enterDelay={100}>
         <Button
           color="primary"
           variant="contained"


### PR DESCRIPTION
#### Type of pull request

Specify the type of pull request.
 Ui Fix
---

#### The issue
The inlineCodeComment modal has a text that reads "Markdown is supported", but a user may not know it's a link that leads to an article about how to write a markdown.

---

#### The Solution

The solution adopted is to add an openInNew icon to inlineCodeComment text "Markdown is supported"

---

#### Screenshots (if there are changes of UI)
Before
<img width="1280" alt="Screen Shot 2020-02-20 at 3 58 51 PM" src="https://user-images.githubusercontent.com/26705668/74946696-ffb16780-53f9-11ea-885b-ecdafd8042c2.png">

After
<img width="1280" alt="Screen Shot 2020-02-20 at 3 41 28 PM" src="https://user-images.githubusercontent.com/26705668/74946738-0d66ed00-53fa-11ea-9123-da27e9378bcc.png">

---

#### Task Ticket(s)
No ticket
---

### Developer (PR owner) Checklist

- [+] Tested changes.
- [+] Double-checked target branch

### Reviewer Checklist

- [ ] I understand _why_ and _how_.
- [ ] I have read the code review guide at https://www.notion.so/f9labs/Code-Review-Guide-2de31a969bbb4207992a9cb07d6273e3
