### PR TITLE
Add refresh and clear functionality to the console

### DIFF
--- a/src/components/Console/index.tsx
+++ b/src/components/Console/index.tsx
@@ -218,9 +218,11 @@ const Console: React.FC<{
 
   function renderTerminalBasedActions() {
     return (
-      <div className={classes.consoleTerminalBasedActionsContainer}>
-        <ClearIcon className={classes.consoleTerminalClearIcon} onClick={handleClearConsole} />
-      </div>
+      currentTab === 0 && (
+        <div className={classes.consoleTerminalBasedActionsContainer}>
+          <ClearIcon className={classes.consoleTerminalClearIcon} onClick={handleClearConsole} />
+        </div>
+      )
     );
   }
 

--- a/src/components/Console/index.tsx
+++ b/src/components/Console/index.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Tabs, Tab } from '@material-ui/core';
-import { Warning as WarningIcon, Error as ErrorIcon } from '@material-ui/icons';
+import {
+  Warning as WarningIcon,
+  Error as ErrorIcon,
+  NotInterested as ClearIcon,
+} from '@material-ui/icons';
 
 import { useStyles } from './styles';
 import { useStyles as commonUseStyles } from '../../Css';
@@ -29,12 +33,21 @@ type TerminalMessagesType = TerminalMessageType[];
 
 const Console: React.FC<{
   sourceCode: string;
+  sourceCodeHash: null | number;
   fetchedReadme: string;
   onSetNotificationSettings: any;
   ownerId: string;
   Api: any;
   user: any;
-}> = ({ sourceCode, ownerId, fetchedReadme, onSetNotificationSettings, Api, user }) => {
+}> = ({
+  sourceCode,
+  sourceCodeHash,
+  ownerId,
+  fetchedReadme,
+  onSetNotificationSettings,
+  Api,
+  user,
+}) => {
   const [currentTab, setCurrentTab] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isSignInModalVisible, setIsSignInModalVisible] = useState<boolean>(false);
@@ -56,9 +69,11 @@ const Console: React.FC<{
   }, []);
 
   useEffect(() => {
-    setTerminalMessages([]);
-    workerRef.current.postMessage({ sourceCode });
-  }, [sourceCode]);
+    if (!!sourceCodeHash === true) {
+      setTerminalMessages([]);
+      workerRef.current.postMessage({ sourceCode });
+    }
+  }, [sourceCodeHash, sourceCode]);
 
   useEffect(() => {
     setReadMe(fetchedReadme);
@@ -78,6 +93,10 @@ const Console: React.FC<{
 
   function handleCloseSignInModal() {
     setIsSignInModalVisible(false);
+  }
+
+  function handleClearConsole() {
+    setTerminalMessages([]);
   }
 
   function submitReadme() {
@@ -104,7 +123,16 @@ const Console: React.FC<{
   function renderLogBasedMessages(message: string, index: number) {
     return (
       <div className={classes.consoleTerminalLogMessages} key={index}>
-        <Typography thickness="semi-bold">{message}</Typography>
+        <Typography thickness="regular">{message}</Typography>
+      </div>
+    );
+  }
+
+  function renderConsoleClearedMessage() {
+    return (
+      <div
+        className={`${classes.consoleTerminalLogMessages} ${classes.consoleTerminalClearMessage}`}>
+        <Typography thickness="regular">Console was cleared</Typography>
       </div>
     );
   }
@@ -115,7 +143,7 @@ const Console: React.FC<{
         <div>
           <WarningIcon className={classes.consoleTerminalWarningIcon} />
         </div>
-        <Typography color="warning" thickness="semi-bold">
+        <Typography color="warning" thickness="regular">
           {message}
         </Typography>
       </div>
@@ -128,7 +156,7 @@ const Console: React.FC<{
         <div>
           <ErrorIcon className={classes.consoleTerminalErrorIcon} />
         </div>
-        <Typography color="error" thickness="semi-bold">
+        <Typography color="error" thickness="regular">
           {message}
         </Typography>
       </div>
@@ -138,6 +166,7 @@ const Console: React.FC<{
   function renderTerminal() {
     return (
       <div className={classes.consoleSection}>
+        {renderConsoleClearedMessage()}
         {terminalMessages.map((terminalMessage: TerminalMessageType, i: number) => {
           if (terminalMessage.type === MessageType.LOG) {
             return renderLogBasedMessages(terminalMessage.message, i);
@@ -187,13 +216,24 @@ const Console: React.FC<{
     );
   }
 
+  function renderTerminalBasedActions() {
+    return (
+      <div className={classes.consoleTerminalBasedActionsContainer}>
+        <ClearIcon className={classes.consoleTerminalClearIcon} onClick={handleClearConsole} />
+      </div>
+    );
+  }
+
   return (
     <section className={classes.console}>
-      <Tabs value={currentTab} onChange={handleTabChange} aria-label="console tabs">
-        <Tab label="TERMINAL" {...a11yProps(0)} />
-        {isAuthorize && <Tab label="READ ME" {...a11yProps(1)} />}
-        <Tab label={isAuthorize ? 'PREVIEW' : 'READ ME'} {...a11yProps(2)} />
-      </Tabs>
+      <div>
+        <Tabs value={currentTab} onChange={handleTabChange} aria-label="console tabs">
+          <Tab label="TERMINAL" {...a11yProps(0)} />
+          {isAuthorize && <Tab label="READ ME" {...a11yProps(1)} />}
+          <Tab label={isAuthorize ? 'PREVIEW' : 'READ ME'} {...a11yProps(2)} />
+        </Tabs>
+        {renderTerminalBasedActions()}
+      </div>
       {currentTab === 0 && renderTerminal()}
       {currentTab === 1 && isAuthorize ? renderReadMe() : renderPreview()}
       {currentTab === 2 && renderPreview()}

--- a/src/components/Console/styles.ts
+++ b/src/components/Console/styles.ts
@@ -6,6 +6,21 @@ export const useStyles = makeStyles(theme => ({
   console: {
     height: '100vh',
     backgroundColor: color.darkThemeBlack,
+    '&>div:first-child': {
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'space-between',
+      paddingRight: theme.spacing(25),
+    },
+  },
+  consoleTerminalBasedActionsContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  consoleTerminalClearIcon: {
+    color: color.white,
+    fontSize: 16,
+    cursor: 'pointer',
   },
   consoleTab: {
     color: color.white,
@@ -21,6 +36,9 @@ export const useStyles = makeStyles(theme => ({
     padding: '3px 15px',
     borderBottom: `1px solid ${color.darkThemeLightBorder}`,
     fontSize: `${fontsize.terminal}px !important`,
+  },
+  consoleTerminalClearMessage: {
+    fontStyle: 'italic',
   },
   consoleTerminalWarningMessages: {
     padding: '3px 15px',

--- a/src/components/MonacoEditor/index.tsx
+++ b/src/components/MonacoEditor/index.tsx
@@ -17,7 +17,13 @@ import SourceCodeHeading from './SourceCodeHeading';
 
 interface IProps {
   value?: string;
-  onRunSourceCode?: (value: string) => void;
+  onRunSourceCode?: ({
+    sourceCode,
+    sourceCodeHash,
+  }: {
+    sourceCode: string;
+    sourceCodeHash: number;
+  }) => void;
   theme?: 'light' | 'dark' | 'ace' | 'night-dark';
   language?: string;
   onHandleLoading: any;
@@ -156,7 +162,7 @@ const MonacoEditor: React.FC<IProps> = ({
   }, [selectionValue, selectionRange]);
 
   function handleSourceCodeExecution() {
-    onRunSourceCode && onRunSourceCode(sourceCode);
+    onRunSourceCode && onRunSourceCode({ sourceCode, sourceCodeHash: Date.now() });
   }
 
   function disableEditor(disable = false) {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -20,7 +20,10 @@ interface IProps {
 }
 
 const Home: React.FC<IProps> = ({ onSetNotificationSettings, Api }) => {
-  const [terminalExecutableCode, setTerminalExecutableCode] = useState('');
+  const [terminalExecutableCode, setTerminalExecutableCode] = useState<{
+    sourceCode: string;
+    sourceCodeHash: null | number;
+  }>({ sourceCode: '', sourceCodeHash: null });
   const [currentSection, setCurrentSection] = useState<'comments' | 'console'>('console');
   const [user, setUser] = useState<any>(null);
   const [isLoading, setisLoading] = useState<boolean>(false);
@@ -149,7 +152,8 @@ const Home: React.FC<IProps> = ({ onSetNotificationSettings, Api }) => {
               }`}>
               <Console
                 ownerId={fetchedSourceCode.ownerId}
-                sourceCode={terminalExecutableCode}
+                sourceCode={terminalExecutableCode.sourceCode}
+                sourceCodeHash={terminalExecutableCode.sourceCodeHash}
                 fetchedReadme={fetchedSourceCode.readme}
                 user={user}
               />


### PR DESCRIPTION
#### Type of pull request

Specify the type of pull request.

---

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring

#### The issue
Previously, there was no UI intuition to show that the terminal refreshes when the source code is run. Also there was no way to clear the terminal

---

#### The Solution
To solve this, I added a clear icon that appears only when the user is on the terminal tab so the user can manually clear the terminal. Also whenever the run button is clicked, it needs to create a new source code hash, we use this hash to determine if the user clicked on the run button, thereafter refresh the terminal and display the source code.

---

#### Screenshots (if there are changes of UI)
<img width="1440" alt="Screenshot 2020-02-22 at 21 17 52" src="https://user-images.githubusercontent.com/12268442/75098628-d428ab80-55b8-11ea-932b-b340c1192ede.png">


---

#### Task Ticket(s)
-> https://github.com/gbenga504/javico/issues/31
-> https://github.com/gbenga504/javico/issues/32

---

### Developer (PR owner) Checklist

- [x] Tested changes.
- [x] Double-checked target branch

### Reviewer Checklist

- [ ] I understand _why_ and _how_.
- [ ] I have read the code review guide at https://www.notion.so/f9labs/Code-Review-Guide-2de31a969bbb4207992a9cb07d6273e3
