### PR TITLE
Make inline code comment close when the user press the escape key

### DIFF
--- a/packages/common/src/components/InlineCodeComment/index.tsx
+++ b/packages/common/src/components/InlineCodeComment/index.tsx
@@ -159,7 +159,7 @@ const InlineCodeComment: React.FC<IProps> = ({
       onKeyUp={handleKeyUp}
       className={`${classes.commentBoxContainer} ${commonCss.fullHeightAndWidth}`}
       style={{
-        top: distanceY || 0 //+ 20
+        top: distanceY || 0
       }}
     >
       <form

--- a/packages/common/src/components/InlineCodeComment/index.tsx
+++ b/packages/common/src/components/InlineCodeComment/index.tsx
@@ -96,6 +96,13 @@ const InlineCodeComment: React.FC<IProps> = ({
     onOk(comment);
   }
 
+  function handleKeyUp(event: React.KeyboardEvent) {
+    if (event.key === "Escape" && !!visible) {
+      event.preventDefault();
+      onRequestClose();
+    }
+  }
+
   function renderWriteComment() {
     return (
       <>
@@ -149,9 +156,10 @@ const InlineCodeComment: React.FC<IProps> = ({
 
   return visible === true ? (
     <div
+      onKeyUp={handleKeyUp}
       className={`${classes.commentBoxContainer} ${commonCss.fullHeightAndWidth}`}
       style={{
-        top: (distanceY || 0) + 20
+        top: distanceY || 0 //+ 20
       }}
     >
       <form

--- a/packages/common/src/components/MonacoEditor/index.tsx
+++ b/packages/common/src/components/MonacoEditor/index.tsx
@@ -27,8 +27,7 @@ interface IProps {
   ) => void;
   theme?: "light" | "dark" | "ace" | "night-dark" | "vs-dark";
   language?: string;
-  isInlineCodeCommentVisible: boolean;
-  onHandleCloseInlineCodeComment: () => void;
+  onPressEscape?: () => void;
 }
 
 const MonacoEditor = React.forwardRef(
@@ -40,8 +39,7 @@ const MonacoEditor = React.forwardRef(
       onHighlightValue,
       theme = "vs-dark",
       language = "javascript",
-      isInlineCodeCommentVisible,
-      onHandleCloseInlineCodeComment
+      onPressEscape
     }: IProps,
     ref
   ) => {
@@ -249,9 +247,9 @@ const MonacoEditor = React.forwardRef(
     }
 
     function handleKeyUp(event: React.KeyboardEvent) {
-      if (event.key === "Escape" && !!isInlineCodeCommentVisible) {
+      if (event.key === "Escape") {
         event.preventDefault();
-        onHandleCloseInlineCodeComment();
+        onPressEscape && onPressEscape();
       }
       handleHideCommentIcon();
     }

--- a/packages/common/src/components/MonacoEditor/index.tsx
+++ b/packages/common/src/components/MonacoEditor/index.tsx
@@ -27,6 +27,8 @@ interface IProps {
   ) => void;
   theme?: "light" | "dark" | "ace" | "night-dark" | "vs-dark";
   language?: string;
+  isInlineCodeCommentVisible: boolean;
+  onHandleCloseInlineCodeComment: () => void;
 }
 
 const MonacoEditor = React.forwardRef(
@@ -37,7 +39,9 @@ const MonacoEditor = React.forwardRef(
       onSaveValue,
       onHighlightValue,
       theme = "vs-dark",
-      language = "javascript"
+      language = "javascript",
+      isInlineCodeCommentVisible,
+      onHandleCloseInlineCodeComment
     }: IProps,
     ref
   ) => {
@@ -244,6 +248,14 @@ const MonacoEditor = React.forwardRef(
       }
     }
 
+    function handleKeyUp(event: React.KeyboardEvent) {
+      if (event.key === "Escape" && !!isInlineCodeCommentVisible) {
+        event.preventDefault();
+        onHandleCloseInlineCodeComment();
+      }
+      handleHideCommentIcon();
+    }
+
     function handleSaveSourceCode(event: React.KeyboardEvent) {
       if (
         (event.ctrlKey === true || event.metaKey === true) &&
@@ -301,7 +313,7 @@ const MonacoEditor = React.forwardRef(
         <div className={classes.monacoEditorContainer}>
           {renderLoading()}
           <div
-            onKeyUp={handleHideCommentIcon}
+            onKeyUp={handleKeyUp}
             onKeyDown={handleSaveSourceCode}
             onMouseUp={handleHighlightText}
             ref={nodeRef}

--- a/packages/desktop-web-app/src/components/Editor/index.tsx
+++ b/packages/desktop-web-app/src/components/Editor/index.tsx
@@ -259,6 +259,8 @@ const Editor: React.FC<IProps> = ({
           onChangeValue={handleSourceCodeChange}
           onSaveValue={handleSaveSourceCode}
           onHighlightValue={handleCodeHighlight}
+          onHandleCloseInlineCodeComment={handleCloseInlineCodeComment}
+          isInlineCodeCommentVisible={Boolean(commentAnchorDistanceY)}
         />
         <InlineCodeComment
           visible={Boolean(commentAnchorDistanceY)}

--- a/packages/desktop-web-app/src/components/Editor/index.tsx
+++ b/packages/desktop-web-app/src/components/Editor/index.tsx
@@ -267,8 +267,11 @@ const Editor: React.FC<IProps> = ({
             onChangeValue={handleSourceCodeChange}
             onSaveValue={handleSaveSourceCode}
             onHighlightValue={handleCodeHighlight}
-            onHandleCloseInlineCodeComment={handleCloseInlineCodeComment}
-            isInlineCodeCommentVisible={Boolean(commentAnchorDistanceY)}
+            onPressEscape={
+              Boolean(commentAnchorDistanceY) === true
+                ? handleCloseInlineCodeComment
+                : undefined
+            }
           />
           <InlineCodeComment
             visible={Boolean(commentAnchorDistanceY)}


### PR DESCRIPTION
#### Type of pull request

Specify the type of pull request.

---

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring

#### The issue

Decribe (in details) the purpose of the pull request

This PR adds the ability for the user to be able to close the inlinecodecomment modal when the escape key is pressed

---

#### The Solution

Describe (in details) your implementation (how you solved the issue)

Add an onkeyup event listener to the container of the inlinecodecomment modal

---

#### Screenshots (if there are changes of UI)

If any changes affect UI or an image will add more context to the solution, please attach a before/after screenshots below.

---

#### Task Ticket(s)

Reference link to the issue if any

---

### Developer (PR owner) Checklist

- [x] Tested changes.
- [x] Double-checked target branch

### Reviewer Checklist

- [x] I understand _why_ and _how_.
