### PR TITLE
Enable react-syntax-highlighter to show the original line the code th…

### DIFF
--- a/packages/common/src/apis/comments.ts
+++ b/packages/common/src/apis/comments.ts
@@ -9,6 +9,7 @@ interface IPayload {
     text: string;
     codeReference?: string;
     clientTimestamp?: number;
+    codeReferenceStartLine?: number | null;
   };
   params: {
     sourceCodeID: string;

--- a/packages/common/src/components/CommentListView/Comment.tsx
+++ b/packages/common/src/components/CommentListView/Comment.tsx
@@ -38,6 +38,7 @@ interface IProps {
   authorName: string;
   authorPhotoURL: string;
   createdAt: number;
+  startingLineNumber?: number;
   onRequestReply?: (comment: string, id: string) => void;
   userId: string;
   authorId: string;
@@ -73,7 +74,8 @@ const Comment: React.FC<IProps> = ({
   onShowReplies,
   onHideReplies,
   repliesProps,
-  editMessagePanelProps
+  editMessagePanelProps,
+  startingLineNumber
 }) => {
   const [isRepliesVisible, setIsRepliesVisible] = useState<boolean>(false);
   const [optionsAnchorEl, setOptionsAnchorEl] = useState<null | SVGSVGElement>(
@@ -219,6 +221,7 @@ const Comment: React.FC<IProps> = ({
           <SyntaxHighlighter
             containerStyle={{ marginTop: 5 }}
             sourceCode={codeReference}
+            startingLineNumber={startingLineNumber}
           />
         )}
         {!!repliesProps.numReplies === true && repliesProps.numReplies > 0 && (

--- a/packages/common/src/components/MonacoEditor/index.tsx
+++ b/packages/common/src/components/MonacoEditor/index.tsx
@@ -23,7 +23,8 @@ interface IProps {
   onHighlightValue: (
     highlightedValue: string,
     anchorEl: HTMLDivElement | null,
-    distanceY: number
+    distanceY: number,
+    startLineNumber: number
   ) => void;
   theme?: "light" | "dark" | "ace" | "night-dark" | "vs-dark";
   language?: string;
@@ -221,7 +222,8 @@ const MonacoEditor = React.forwardRef(
         commentIconRef.current,
         commentIconRef.current
           ? commentIconRef.current.getBoundingClientRect().top
-          : 0
+          : 0,
+        selectionRange.startLineNumber
       );
       handleHideCommentIcon();
     }

--- a/packages/common/src/components/SyntaxHighlighter/index.tsx
+++ b/packages/common/src/components/SyntaxHighlighter/index.tsx
@@ -8,12 +8,14 @@ import { useStyles } from "./styles";
 interface IProps {
   containerStyle?: any;
   sourceCode: string;
+  startingLineNumber?: number;
 }
 
 ReactSyntaxHighlighter.registerLanguage("javascript", js);
 const SyntaxHighlighter: React.FC<IProps> = ({
   containerStyle,
-  sourceCode
+  sourceCode,
+  startingLineNumber
 }) => {
   const classes = useStyles();
 
@@ -24,6 +26,7 @@ const SyntaxHighlighter: React.FC<IProps> = ({
       showLineNumbers={true}
       customStyle={{ margin: 0, padding: 0, ...containerStyle }}
       lineNumberContainerProps={{ className: classes.lineNumbersContainer }}
+      startingLineNumber={startingLineNumber}
     >
       {sourceCode}
     </ReactSyntaxHighlighter>

--- a/packages/common/src/utils/Apis.ts
+++ b/packages/common/src/utils/Apis.ts
@@ -68,6 +68,7 @@ export interface IComment {
   createdAt: number;
   numReplies: number;
   updatedAt?: string;
+  codeReferenceStartLine?: number;
   clientTimestamp: number;
 }
 

--- a/packages/desktop-web-app/src/components/CommentListHandler/index.tsx
+++ b/packages/desktop-web-app/src/components/CommentListHandler/index.tsx
@@ -410,6 +410,7 @@ const CommentListHandler: React.FC<IProps> = ({
             createdAt={item.createdAt}
             userId={(currentUser && currentUser.uid) || null}
             authorId={item.author.id}
+            startingLineNumber={item.codeReferenceStartLine}
             editMessagePanelProps={{
               inputClassName: classes.editPanelInput,
               cancelButtonClassName: classes.editPanelCancelButton

--- a/packages/desktop-web-app/src/components/Editor/index.tsx
+++ b/packages/desktop-web-app/src/components/Editor/index.tsx
@@ -71,6 +71,9 @@ const Editor: React.FC<IProps> = ({
   const [isSignInModalVisible, setIsSignInModalVisible] = useState<boolean>(
     false
   );
+  const [codeReferenceStartLine, setCodeReferenceStartLine] = useState<
+    number | null
+  >(null);
   const [sourceCode, setSourceCode] = useState<string>("");
   const editorRef = useRef<any>(null);
   const classes = useStyles();
@@ -116,10 +119,12 @@ const Editor: React.FC<IProps> = ({
   function handleCodeHighlight(
     highlightedValue: string,
     anchorEl: HTMLDivElement | null,
-    distanceY: number
+    distanceY: number,
+    startLineNumber: number
   ) {
     setSelectionValue(highlightedValue);
     setCommentAnchorDistanceY(distanceY);
+    setCodeReferenceStartLine(startLineNumber);
   }
 
   function handleCloseInlineCodeComment() {
@@ -214,7 +219,8 @@ const Editor: React.FC<IProps> = ({
               photoURL: currentUser.photoURL
             },
             text: comment,
-            codeReference: selectionValue
+            codeReference: selectionValue,
+            codeReferenceStartLine
           },
           params: {
             sourceCodeID: sourceCodeId


### PR DESCRIPTION
…at was referenced started from

#### Type of pull request

Specify the type of pull request.

---

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring

#### The issue

Decribe (in details) the purpose of the pull request

When the user reference a part of the author's code, the syntax highlighter starts counting the code line from 1 whereas the code referenced, may not start from line one. 

---

#### The Solution

Describe (in details) your implementation (how you solved the issue)

Add the startline of the code referenced as a param when making a new comment

---

#### Screenshots (if there are changes of UI)

If any changes affect UI or an image will add more context to the solution, please attach a before/after screenshots below.

<img width="1280" alt="Screen Shot 2020-05-06 at 1 18 28 PM" src="https://user-images.githubusercontent.com/26705668/81177653-f0749b80-8f9e-11ea-854b-13b16a9e4f31.png">


---

#### Task Ticket(s)

Reference link to the issue if any

---

### Developer (PR owner) Checklist

- [x] Tested changes.
- [x] Double-checked target branch

### Reviewer Checklist

- [x] I understand _why_ and _how_.
